### PR TITLE
Update board-meetings.ts

### DIFF
--- a/src/app/resources/meetings/board-meetings.ts
+++ b/src/app/resources/meetings/board-meetings.ts
@@ -47,7 +47,7 @@ export const boardMeetings: Meeting[] = [
   {
     date: "November 4 2025",
     agenda:
-      "hhttps://docs.google.com/document/d/1M39Y_S_-bSM57KNo2xk6oOc6dh7Z9XPf-TOU6PyToIM/edit?usp=sharing",
+      "https://docs.google.com/document/d/1M39Y_S_-bSM57KNo2xk6oOc6dh7Z9XPf-TOU6PyToIM/edit?usp=sharing",
     minutes:
       "https://docs.google.com/document/d/1jSU3kAJQSe1HBbH1lcaOiRWoAwgDRRzGQjrgdwfgAXM/edit?usp=sharing",
   },
@@ -89,9 +89,9 @@ export const boardMeetings: Meeting[] = [
   {
     date: "July 24 2025",
     agenda:
-      "https://docs.google.com/document/d/1nht_22OvolQHR6qacc8ZxQjPlowgVQsDaCHoSvUhvCc/edit?usp=sharing",
+      "https://docs.google.com/document/d/1c7-KpXUTv8JtZ84sWZXnsI5tfqXxGPiDh4tXqqAGYgc/edit?usp=sharing",
     minutes:
-      "https://docs.google.com/document/d/1sQCKljK989U6ulQuvjzZ04kyfoNHpa4jb9uSKJK5SfU/edit?usp=sharing",
+      "https://docs.google.com/document/d/1iBYLGC6NCYtQl170Jw1C8P_rmYnAOY95_m-O4hinQPA/edit?usp=sharing",
   },
   {
     date: "January 16 2025",


### PR DESCRIPTION
the may 14, 2025 and june 4, 2025 agenda aren't publically viewable - update: made them viewable
the july 24, 2025 agenda and minutes link to the september 17, 2024 agenda and minutes for some reason - update: went back and fixed the links
the november 4, 2025 agenda link has an extra "h" in "https", causing the link to be broken - update: removed extra "h"